### PR TITLE
chore: set the package module system to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.29.2",
   "private": true,
   "packageManager": "pnpm@7.23.0",
+  "type": "module",
   "scripts": {
     "dev": "vitepress --port 3333 --open",
     "build": "nr prefetch && vitepress build",


### PR DESCRIPTION
启动项目的时候提示 ` [WARNING] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]` ，找到原因发现是因为没有在 package.json 中设置 `type` 为 `module` 导致 esbuild 误认为每个 module 是 `cjs` 模块。