### PR TITLE
docs: add nav config activeMatch

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -183,10 +183,10 @@ export default withPwa(
       },
 
       nav: [
-        { text: '指南', link: '/guide/' },
-        { text: 'API', link: '/api/' },
-        { text: '配置', link: '/config/' },
-        { text: 'Advanced', link: '/advanced/api' },
+        { text: '指南', link: '/guide/', activeMatch: '^/guide/' },
+        { text: 'API', link: '/api/', activeMatch: '^/api/' },
+        { text: '配置', link: '/config/', activeMatch: '^/config/' },
+        { text: 'Advanced', link: '/advanced/api', activeMatch: '^/advanced/' },
         {
           text: `v${version}`,
           items: [


### PR DESCRIPTION
add activeMatch option in nav config , it can highlight the nav title In the same place

<img width="968" alt="image" src="https://user-images.githubusercontent.com/96854855/234225051-9ec23cb8-31e5-4cba-a2be-4f4db05ec42e.png">
