### PR TITLE
Update test-context.md

### DIFF
--- a/guide/test-context.md
+++ b/guide/test-context.md
@@ -177,9 +177,9 @@ const myTest = test.extend<MyFixtures>({
   archive: [],
 })
 
-myTest('', (context) => {
-  expectTypeOf(context.todos).toEqualTypeOf<number[]>()
-  expectTypeOf(context.archive).toEqualTypeOf<number[]>()
+myTest('', ({ todos, archive }) => {
+  expectTypeOf(todos).toEqualTypeOf<number[]>()
+  expectTypeOf(archive).toEqualTypeOf<number[]>()
 })
 ```
 


### PR DESCRIPTION
解决如下报错：
Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "context".