### PR TITLE
docs: Delete English that has been translated

### DIFF
--- a/api/vi.md
+++ b/api/vi.md
@@ -142,12 +142,10 @@ axios.get(`/apples/${increment(1)}`);
 ```
 
 ::: warning
-Beware that if you don't call `vi.mock`, modules **are not** mocked automatically. To replicate Jest's automocking behaviour, you can call `vi.mock` for each required module inside [`setupFiles`](/config/#setupfiles).
 
 请注意，如果不调用 `vi.mock` ，模块**不会**被自动模拟。要复制 Jest 的自动锁定行为，可以在 [`setupFiles`](/config/#setupfiles) 中为每个所需的模块调用 `vi.mock` 。
 :::
 
-If there is no `__mocks__` folder or a factory provided, Vitest will import the original module and auto-mock all its exports. For the rules applied, see [algorithm](/guide/mocking#automocking-algorithm).
 
 如果没有提供 `__mocks__` 文件夹或工厂，Vitest 将导入原始模块并自动模拟其所有输出。有关应用的规则，请参阅[模块](/guide/mocking#%E6%A8%A1%E5%9D%97)。
 


### PR DESCRIPTION
This section of the document has actually been translated into Chinese, and it seems that the English part can be removed.

![image](https://github.com/vitest-dev/docs-cn/assets/117748716/bbc51b85-6139-4d76-b6fd-17160180d48a)
