### PR TITLE
Update mock.md

### DIFF
--- a/api/mock.md
+++ b/api/mock.md
@@ -200,13 +200,7 @@ await asyncMock() // throws Error<'Async error'>
 function mockReset(): MockInstance<T>
 ```
 
-执行 `mockClear` 的功能，并重置内部实现为原始函数。
-这也将重置所有“一次性”实现。
-
-需要注意一下，重置来自 `vi.fn()` 的模拟将把实现设置为返回 `undefined` 的空函数。
-重置来自 `vi.fn(impl)` 的模拟将把实现恢复为 `impl` 。
-
-这在我们想要将模拟重置为其原始状态时非常有用。
+执行与 `mockClear` 相同的操作，并将内部实现设置为空函数（调用时返回 undefined）。这也会重置所有 “once” 实现。它对于将 mock 完全重置为其默认状态很有用。
 
 要在每个测试之前自动调用此方法，请在配置中启用 [`mockReset`](/config/#mockreset) 设置。
 
@@ -216,7 +210,7 @@ function mockReset(): MockInstance<T>
 function mockRestore(): MockInstance<T>
 ```
 
-执行 `mockReset` 所做的操作，并恢复被 spied 对象的原始描述符。
+执行与 `mockReset` 相同的操作，并将内部实现恢复为原始函数。
 
 需要注意一下，从 `vi.fn()` 恢复的模拟将把实现设置为返回 `undefined` 的空函数。
 从 `vi.fn(impl)` 恢复的模拟将把实现恢复为 `impl` 。


### PR DESCRIPTION
修正mockReset的翻译，mockReset方法并不会把vi.fn(impl) 的模拟实现恢复为 impl。