### PR TITLE
docs(zh): fix Chinese translations for lastUpdatedText and docFooter

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -110,7 +110,11 @@ export default ({ mode }: { mode: string }) => {
     },
     themeConfig: {
       logo: '/logo.svg',
-
+      lastUpdatedText: '最后更新',
+      docFooter: {
+        prev: '上一页',
+        next: '下一页',
+      },
       editLink: {
         pattern: 'https://github.com/vitest-dev/docs-cn/edit/dev/:path',
         text: '在 GitHub 上编辑此页面',


### PR DESCRIPTION
<!-- 感谢你的贡献！ -->

### 在提交PR之前，请确保您执行以下操作:
- [x] 曾阅读过[翻译须知](https://github.com/vitest-dev/docs-cn/issues/391)。
- [x] 检查是否已经有PR以同样的方式解决问题，以避免创建重复。
- [x] 在此PR中描述正在解决的问题，或引用它解决的问题（例如：`fixes #123`）。
---

### 描述
<!-- 请在此处插入您的描述，并提供有关此PR正在解决的 “内容” 的特别信息 -->
This PR mainly fixes the Chinese translations for the following three UI strings in `themeConfig`:

- `lastUpdatedText`: updated to `'最后更新'`
- `docFooter.prev`: updated to `'上一页'`
- `docFooter.next`: updated to `'下一页'`

### 附加上下文
<!-- 例如，你有什么想让代码审核的人重点关注的内容。 -->
