### PR TITLE
docs(cn): translate `config/index` missing content

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -23,7 +23,7 @@ export default defineConfig({
   },
 })
 ```
-如果你已经在使用 `Vite`，请在 `Vite` 配置中添加 `test` 属性。你还需要使用 `/// <reference types="vitest/config" />` 在你的配置文件的顶部引用。
+如果你已经有一个 `vite` 配置文件，可以通过 `/// <reference types="vitest/config" />` 来引入 `test` 类型声明：
 
 ```js [vite.config.js]
 /// <reference types="vitest/config" />

--- a/config/index.md
+++ b/config/index.md
@@ -79,4 +79,4 @@ export default defineConfig(configEnv => mergeConfig(
 
 由于 Vitest 使用 Vite 的配置，我们也可以使用 [Vite](https://vitejs.dev/config/) 中的任何配置选项。例如，使用 `define` 来定义全局变量，或者使用 `resolve.alias` 来定义别名——这些选项应该在顶级定义，而不是在 `test` 属性内部。
 
-所有不支持在项目配置中使用的配置选项，在 [配置](/guide/projects) 指南中会用 <CRoot />  标记。它们必须在根配置文件中定义一次。
+在 [项目](/guide/projects) 配置中不支持的配置选项旁边会显示 <CRoot /> 图标。这意味着它们只能在 Vitest 根配置文件中进行设置。

--- a/config/index.md
+++ b/config/index.md
@@ -36,7 +36,7 @@ export default defineConfig({
 })
 ```
 
-如果你需要，你可以通过检索 Vitest 的默认选项来扩展：
+你可以获取 Vitest 的默认配置，以便在需要时扩展它们：
 
 ```js [vitest.config.js]
 import { configDefaults, defineConfig } from 'vitest/config'

--- a/config/index.md
+++ b/config/index.md
@@ -12,7 +12,7 @@ outline: deep
 
 要配置 Vitest 本身，请在我们的 Vite 配置中添加 `test` 属性。如果我们是从 `vite` 本身导入 `defineConfig`，我们还需要在配置文件顶部使用 [三斜杠指令](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) 添加对 Vitest 类型引用。
 
-如果你不使用 `vite` ，你可以通过 `vitest/config` 中的 `defineConfig` 去配置你的文件：
+如果你尚未使用 `vite` ，可以在配置文件中从 `vitest/config` 导入 `defineConfig`：
 
 ```js [vitest.config.js]
 import { defineConfig } from 'vitest/config'

--- a/config/index.md
+++ b/config/index.md
@@ -12,8 +12,7 @@ outline: deep
 
 要配置 Vitest 本身，请在我们的 Vite 配置中添加 `test` 属性。如果我们是从 `vite` 本身导入 `defineConfig`，我们还需要在配置文件顶部使用 [三斜杠指令](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) 添加对 Vitest 类型引用。
 
-<!-- TODO: translation -->
-If you are not using `vite`, add `defineConfig` imported from `vitest/config` to your config file:
+如果你不使用 `vite` ，你可以通过 `vitest/config` 中的 `defineConfig` 去配置你的文件：
 
 ```js [vitest.config.js]
 import { defineConfig } from 'vitest/config'
@@ -24,8 +23,7 @@ export default defineConfig({
   },
 })
 ```
-<!-- TODO: translation -->
-If you have a `vite` config already, you can add `/// <reference types="vitest/config" />` to include the `test` types:
+如果你已经在使用 `Vite`，请在 `Vite` 配置中添加 `test` 属性。你还需要使用 `/// <reference types="vitest/config" />` 在你的配置文件的顶部引用。
 
 ```js [vite.config.js]
 /// <reference types="vitest/config" />
@@ -38,7 +36,7 @@ export default defineConfig({
 })
 ```
 
-You can retrieve Vitest's default options to expand them if needed:
+如果你需要，你可以通过检索 Vitest 的默认选项来扩展：
 
 ```js [vitest.config.js]
 import { configDefaults, defineConfig } from 'vitest/config'
@@ -81,5 +79,4 @@ export default defineConfig(configEnv => mergeConfig(
 
 由于 Vitest 使用 Vite 的配置，我们也可以使用 [Vite](https://vitejs.dev/config/) 中的任何配置选项。例如，使用 `define` 来定义全局变量，或者使用 `resolve.alias` 来定义别名——这些选项应该在顶级定义，而不是在 `test` 属性内部。
 
-<!-- TODO: translation -->
-Configuration options that are not supported inside a [project](/guide/projects) config have <CRoot /> icon next to them. This means they can only be set in the root Vitest config.
+所有不支持在项目配置中使用的配置选项，在 [配置](/guide/projects) 指南中会用 <CRoot />  标记。它们必须在根配置文件中定义一次。


### PR DESCRIPTION
<!-- 感谢你的贡献！ -->

### 在提交PR之前，请确保您执行以下操作:
- [x] 曾阅读过[翻译须知](https://github.com/vitest-dev/docs-cn/issues/391)。
- [x] 检查是否已经有PR以同样的方式解决问题，以避免创建重复。
- [x] 在此PR中描述正在解决的问题，或引用它解决的问题（例如：`fixes #123`）。

---

### 描述
<!-- 请在此处插入您的描述，并提供有关此PR正在解决的 “内容” 的特别信息 -->
翻译配置文件 config/index.md  中缺失的内容

### 附加上下文
<!-- 例如，你有什么想让代码审核的人重点关注的内容。 -->
