### PR TITLE
feat: add custom containers type localization translation

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -83,6 +83,13 @@ export default ({ mode }: { mode: string }) => {
       },
     },
     markdown: {
+      container: {
+        tipLabel: '提示',
+        warningLabel: '注意',
+        dangerLabel: '警告',
+        infoLabel: '说明',
+        detailsLabel: '详情',
+      },
       config(md) {
         md.use(tabsMarkdownPlugin)
         md.use(groupIconMdPlugin)

--- a/api/browser/assertions.md
+++ b/api/browser/assertions.md
@@ -6,7 +6,7 @@ title: Assertion API | 浏览器模式
 
 Vitest 默认提供了一组丰富的 DOM 断言，这些断言源自 [`@testing-library/jest-dom`](https://github.com/testing-library/jest-dom) 库，并增加了对定位器的支持以及内置的重试能力。
 
-::: tip TypeScript Support
+::: tip TypeScript 支持
 如果你正在使用 [TypeScript](/guide/browser/#typescript) 或希望在 `expect` 中获得正确的类型提示，请确保在某个地方引用了 `vitest/browser`。如果你从未从该模块导入过，可以在 `tsconfig.json` 覆盖范围内的任何文件中添加一个 `reference` 注释：
 
 ```ts


### PR DESCRIPTION
<!-- 感谢你的贡献！ -->

### 在提交PR之前，请确保你执行以下操作:
- [x] 曾阅读过[翻译须知](https://github.com/vitest-dev/docs-cn/issues/391)。
- [x] 检查是否已经有PR以同样的方式解决问题，以避免创建重复。
- [x] 在此PR中描述正在解决的问题，或引用它解决的问题（例如：`fixes #123`）。

---

### 描述
<!-- 请在此处插入你的描述，并提供有关此PR正在解决的 “内容” 的特别信息 -->

按照 [翻译须知](https://github.com/vitest-dev/docs-cn/issues/391) 中对于 `alert` 术语约定，添加自定义容器本地化翻译


### 附加上下文
<!-- 例如，你有什么想让代码审核的人重点关注的内容。 -->

具体效果：

<img width="827" height="302" alt="image" src="https://github.com/user-attachments/assets/c3379586-54e5-4e77-a5c4-f4d1a63b70df" />

在后续的翻译工作中，无需处理自定义的容器类型，保持原状即可。

**正确示例**
```md
:::tip
Vitest 需要 Vite >=v6.4.0 和 Node >=v22.12.0
:::

::: warning 异步上下文
与 Node.js 不同，浏览器不具备自动的异步上下文传播能力。Vitest 在内部为测试执行处理这一点，但对于深度嵌套的异步代码中的自定义跨度，上下文可能不会自动传播。
:::
```
**错误示例**
```md
:::tip 提示
Vitest 需要 Vite >=v6.4.0 和 Node >=v22.12.0
:::
```